### PR TITLE
Add FCM support

### DIFF
--- a/src/common/src/main/java/tupperdate/common/dto/NewNotificationTokenDTO.kt
+++ b/src/common/src/main/java/tupperdate/common/dto/NewNotificationTokenDTO.kt
@@ -1,0 +1,8 @@
+package tupperdate.common.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NewNotificationTokenDTO(
+    val token: String,
+)

--- a/src/common/src/main/java/tupperdate/common/dto/notifications/Types.kt
+++ b/src/common/src/main/java/tupperdate/common/dto/notifications/Types.kt
@@ -1,0 +1,26 @@
+package tupperdate.common.dto.notifications
+
+/**
+ * An object with the different keys and values that might be contained in cloud messages. These
+ * constants are shared between the client and the server to ensure convergence.
+ */
+object Notifications {
+    // Key types.
+
+    // All messages have a KeyType.
+    const val KeyType = "tupperdate_type"
+
+    // Only for TypeSyncOneConversation messages.
+    const val KeyArgumentConversationId = "tupperdate_arg_conversation"
+
+    // Only for TypeSyncOneRecipe messages.
+    const val KeyArgumentRecipeId = "tupperdate_arg_recipe"
+
+    // Messages with zero arguments.
+    const val TypeSyncAllOwnRecipes = "tupperdate_act_sync_own_recipes"
+    const val TypeSyncAllStackRecipes = "tupperdate_act_sync_stack_recipes"
+    const val TypeSyncAllConversations = "tupperdate_act_sync_all_conversations"
+    const val TypeSyncProfile = "tupperdate_act_sync_profile"
+    const val TypeSyncOneConversation = "tupperdate_act_sync_one_conversation"
+    const val TypeSyncOneRecipe = "tupperdate_act_sync_one_recipe"
+}

--- a/src/mobile/build.gradle
+++ b/src/mobile/build.gradle
@@ -153,6 +153,8 @@ dependencies {
     implementation platform("com.google.firebase:firebase-bom:26.1.0")
     implementation "com.google.firebase:firebase-auth"
     implementation "com.google.firebase:firebase-firestore"
+    implementation "com.google.firebase:firebase-messaging"
+    implementation "com.google.firebase:firebase-analytics"
 
     // Client-side Ktor dependencies.
     implementation "io.ktor:ktor-client-cio:1.4.3"

--- a/src/mobile/src/main/AndroidManifest.xml
+++ b/src/mobile/src/main/AndroidManifest.xml
@@ -36,6 +36,14 @@
                 android:resource="@xml/paths" />
         </provider>
 
+        <service
+            android:name=".data.features.notifications.impl.TupperdateNotificationService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
         <activity
             android:name=".ui.MainActivity"
             android:windowSoftInputMode="adjustResize" />

--- a/src/mobile/src/main/java/tupperdate/android/Tupperdate.kt
+++ b/src/mobile/src/main/java/tupperdate/android/Tupperdate.kt
@@ -8,6 +8,7 @@ import org.koin.android.ext.koin.androidLogger
 import tupperdate.android.data.KoinDataApiModule
 import tupperdate.android.data.features.auth.KoinModuleDataAuthentication
 import tupperdate.android.data.features.messages.KoinModuleDataMessages
+import tupperdate.android.data.features.notifications.KoinModuleDataNotification
 import tupperdate.android.data.features.recipe.KoinModuleDataRecipe
 import tupperdate.android.ui.home.KoinModuleUIHome
 import tupperdate.android.ui.home.chats.KoinModuleUIMessages
@@ -43,6 +44,7 @@ fun Tupperdate.startKoin() = org.koin.core.context.startKoin {
     modules(KoinModuleDataAuthentication)
     modules(KoinModuleDataMessages)
     modules(KoinModuleDataRecipe)
+    modules(KoinModuleDataNotification)
 
     // Application modules.
     modules(KoinModuleUILoggedIn)

--- a/src/mobile/src/main/java/tupperdate/android/data/features/notifications/Koin.kt
+++ b/src/mobile/src/main/java/tupperdate/android/data/features/notifications/Koin.kt
@@ -1,0 +1,10 @@
+package tupperdate.android.data.features.notifications
+
+import org.koin.dsl.module
+import tupperdate.android.data.InternalDataApi
+import tupperdate.android.data.features.notifications.impl.NotificationRepositoryImpl
+
+val KoinModuleDataNotification = module {
+    @OptIn(InternalDataApi::class)
+    factory<NotificationRepository> { NotificationRepositoryImpl(get()) }
+}

--- a/src/mobile/src/main/java/tupperdate/android/data/features/notifications/Notification.kt
+++ b/src/mobile/src/main/java/tupperdate/android/data/features/notifications/Notification.kt
@@ -1,0 +1,21 @@
+package tupperdate.android.data.features.notifications
+
+import tupperdate.android.data.features.auth.firebase.FirebaseUid
+
+/**
+ * A sealed class representing the different kinds of notification messages that might be received
+ * from the server.
+ *
+ * Different actions might be performed on the client depending on the notification contents.
+ */
+sealed class Notification {
+    // Sync groups of objects.
+    object SyncAllOwnRecipes : Notification()
+    object SyncAllStackRecipes : Notification()
+    object SyncAllConversations : Notification()
+
+    // Sync a single kind of object.
+    object SyncProfile : Notification()
+    data class SyncOneConversation(val id: FirebaseUid) : Notification()
+    data class SyncOneRecipe(val id: String) : Notification()
+}

--- a/src/mobile/src/main/java/tupperdate/android/data/features/notifications/NotificationRepository.kt
+++ b/src/mobile/src/main/java/tupperdate/android/data/features/notifications/NotificationRepository.kt
@@ -1,0 +1,23 @@
+package tupperdate.android.data.features.notifications
+
+/**
+ * A [NotificationRepository] is an interface that lets you perform stuff related to notification
+ * management. In particular, it offers some facilities to link the current device to the remote
+ * server, and handle incoming messages.
+ */
+interface NotificationRepository {
+
+    /**
+     * Links the [NotificationToken] provided to the device to the currently logged in user, if
+     * there is actually any.
+     *
+     * @param token the [NotificationToken] for this device.
+     */
+    fun link(token: NotificationToken)
+
+    /**
+     * Handles the incoming [Notification] and performs data-related side-effects related to it,
+     * including displaying content or updating some local stores.
+     */
+    fun handle(notification: Notification)
+}

--- a/src/mobile/src/main/java/tupperdate/android/data/features/notifications/NotificationToken.kt
+++ b/src/mobile/src/main/java/tupperdate/android/data/features/notifications/NotificationToken.kt
@@ -1,0 +1,12 @@
+package tupperdate.android.data.features.notifications
+
+/**
+ * A token that can be used to send messages uniquely to this device. Generally, this will be
+ * done when the server wants to notify this particular device that some specific content has
+ * changed (for instance, a new chat message might have been sent).
+ *
+ * @param value the unique token that lets the server access this device.
+ */
+data class NotificationToken(
+    val value: String,
+)

--- a/src/mobile/src/main/java/tupperdate/android/data/features/notifications/impl/NotificationRepositoryImpl.kt
+++ b/src/mobile/src/main/java/tupperdate/android/data/features/notifications/impl/NotificationRepositoryImpl.kt
@@ -1,0 +1,61 @@
+package tupperdate.android.data.features.notifications.impl
+
+import android.util.Log
+import androidx.work.WorkManager
+import tupperdate.android.data.InternalDataApi
+import tupperdate.android.data.SyncRequestBuilder
+import tupperdate.android.data.features.auth.work.RefreshProfileWorker
+import tupperdate.android.data.features.messages.work.RefreshAllConversationsWorker
+import tupperdate.android.data.features.messages.work.RefreshMessagesWorker
+import tupperdate.android.data.features.notifications.Notification
+import tupperdate.android.data.features.notifications.NotificationRepository
+import tupperdate.android.data.features.notifications.NotificationToken
+import tupperdate.android.data.features.notifications.work.LinkWorker
+import tupperdate.android.data.features.recipe.work.RefreshOwnWorker
+import tupperdate.android.data.features.recipe.work.RefreshStackWorker
+
+@InternalDataApi
+class NotificationRepositoryImpl(
+    private val manager: WorkManager,
+) : NotificationRepository {
+
+    override fun link(
+        token: NotificationToken,
+    ) {
+        val request = SyncRequestBuilder<LinkWorker>()
+            .setInputData(LinkWorker.forToken(token.value))
+            .build()
+
+        manager.enqueue(request)
+    }
+
+    override fun handle(
+        notification: Notification,
+    ) {
+        Log.d("NotificationRepository", "Got $notification")
+        when (notification) {
+            Notification.SyncAllOwnRecipes -> manager.enqueue(
+                SyncRequestBuilder<RefreshOwnWorker>()
+                    .build()
+            )
+            Notification.SyncAllStackRecipes -> manager.enqueue(
+                SyncRequestBuilder<RefreshStackWorker>()
+                    .build()
+            )
+            Notification.SyncAllConversations -> manager.enqueue(
+                SyncRequestBuilder<RefreshAllConversationsWorker>()
+                    .build()
+            )
+            Notification.SyncProfile -> manager.enqueue(
+                SyncRequestBuilder<RefreshProfileWorker>()
+                    .build()
+            )
+            is Notification.SyncOneConversation -> manager.enqueue(
+                SyncRequestBuilder<RefreshMessagesWorker>()
+                    .setInputData(RefreshMessagesWorker.forConversation(notification.id))
+                    .build()
+            )
+            is Notification.SyncOneRecipe -> Unit // TODO : Handle this case.
+        }
+    }
+}

--- a/src/mobile/src/main/java/tupperdate/android/data/features/notifications/impl/RemoteMessage.kt
+++ b/src/mobile/src/main/java/tupperdate/android/data/features/notifications/impl/RemoteMessage.kt
@@ -1,0 +1,44 @@
+package tupperdate.android.data.features.notifications.impl
+
+import android.util.Log
+import com.google.firebase.messaging.RemoteMessage
+import tupperdate.android.data.InternalDataApi
+import tupperdate.android.data.features.notifications.Notification
+import tupperdate.android.data.features.notifications.Notification.*
+import tupperdate.common.dto.notifications.Notifications.KeyArgumentConversationId
+import tupperdate.common.dto.notifications.Notifications.KeyArgumentRecipeId
+import tupperdate.common.dto.notifications.Notifications.KeyType
+import tupperdate.common.dto.notifications.Notifications.TypeSyncAllConversations
+import tupperdate.common.dto.notifications.Notifications.TypeSyncAllOwnRecipes
+import tupperdate.common.dto.notifications.Notifications.TypeSyncAllStackRecipes
+import tupperdate.common.dto.notifications.Notifications.TypeSyncOneConversation
+import tupperdate.common.dto.notifications.Notifications.TypeSyncOneRecipe
+import tupperdate.common.dto.notifications.Notifications.TypeSyncProfile
+
+/**
+ * Transforms a [RemoteMessage] into a [Notification] that can be used on the client to perform
+ * certain kinds of actions.
+ *
+ * If no corresponding action can be found, a `null` [Notification] will be returned instead.
+ */
+@InternalDataApi
+fun RemoteMessage.toNotification(): Notification? {
+    return when (this.data[KeyType]) {
+        TypeSyncAllOwnRecipes -> SyncAllOwnRecipes
+        TypeSyncAllStackRecipes -> SyncAllStackRecipes
+        TypeSyncAllConversations -> SyncAllConversations
+        TypeSyncProfile -> SyncProfile
+        TypeSyncOneConversation -> when (val id = this.data[KeyArgumentConversationId]) {
+            null -> null
+            else -> SyncOneConversation(id)
+        }
+        TypeSyncOneRecipe -> when (val id = this.data[KeyArgumentRecipeId]) {
+            null -> null
+            else -> SyncOneRecipe(id)
+        }
+        else -> {
+            Log.d("RemoteMessage", "Data ${this.data.entries.joinToString()} not recognized.")
+            null
+        }
+    }
+}

--- a/src/mobile/src/main/java/tupperdate/android/data/features/notifications/impl/TupperdateNotificationService.kt
+++ b/src/mobile/src/main/java/tupperdate/android/data/features/notifications/impl/TupperdateNotificationService.kt
@@ -1,0 +1,35 @@
+package tupperdate.android.data.features.notifications.impl
+
+import android.util.Log
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import org.koin.android.ext.android.inject
+import tupperdate.android.data.InternalDataApi
+import tupperdate.android.data.features.notifications.NotificationRepository
+import tupperdate.android.data.features.notifications.NotificationToken
+
+/**
+ * An implementation of a [FirebaseMessagingService] that will be triggered whenever a new token
+ * for FCM is associated to this app instance.
+ */
+@InternalDataApi
+class TupperdateNotificationService : FirebaseMessagingService() {
+
+    private val repo by inject<NotificationRepository>()
+
+    override fun onNewToken(token: String) {
+        super.onNewToken(token)
+
+        // Send the token to the server.
+        repo.link(NotificationToken(token))
+    }
+
+    override fun onMessageReceived(remote: RemoteMessage) {
+        super.onMessageReceived(remote)
+
+        Log.d("NotificationService", "Got remote message")
+
+        // Send the notification.
+        remote.toNotification()?.let(repo::handle)
+    }
+}

--- a/src/mobile/src/main/java/tupperdate/android/data/features/notifications/work/LinkWorker.kt
+++ b/src/mobile/src/main/java/tupperdate/android/data/features/notifications/work/LinkWorker.kt
@@ -1,0 +1,57 @@
+package tupperdate.android.data.features.notifications.work
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import io.ktor.client.*
+import io.ktor.client.features.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import org.koin.core.component.KoinApiExtension
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import tupperdate.android.data.InternalDataApi
+import tupperdate.common.dto.NewNotificationTokenDTO
+
+/**
+ * A [CoroutineWorker] that links a user's FCM token to their account.
+ */
+@InternalDataApi
+@OptIn(KoinApiExtension::class)
+class LinkWorker(
+    context: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(context, params), KoinComponent {
+
+    private val client by inject<HttpClient>()
+
+    override suspend fun doWork(): Result {
+        val token = inputData.getString(KeyToken) ?: return Result.failure()
+        return try {
+            client.post<Unit>("/notifications") {
+                body = NewNotificationTokenDTO(token)
+            }
+            Result.success()
+        } catch (client: ClientRequestException) {
+            when (client.response.status) {
+                HttpStatusCode.BadRequest -> Result.failure()
+                HttpStatusCode.Unauthorized -> Result.retry()
+                HttpStatusCode.NotFound -> Result.failure()
+                else -> Result.retry()
+            }
+        } catch (problem: Throwable) {
+            Result.retry()
+        }
+    }
+
+    companion object {
+
+        private const val KeyToken = "FCMToken"
+
+        fun forToken(value: String): Data {
+            return workDataOf(KeyToken to value)
+        }
+    }
+}

--- a/src/web/src/main/java/tupperdate/web/Controller.kt
+++ b/src/web/src/main/java/tupperdate/web/Controller.kt
@@ -8,18 +8,24 @@ import io.ktor.routing.*
 import io.ktor.util.pipeline.*
 import org.koin.ktor.ext.inject
 import tupperdate.common.dto.MyUserDTO
-import tupperdate.web.facade.profiles.Profile
-import tupperdate.web.facade.profiles.ProfileFacade
-import tupperdate.web.facade.profiles.toNewProfile
-import tupperdate.web.facade.profiles.toUserDTO
+import tupperdate.common.dto.NewNotificationTokenDTO
+import tupperdate.web.facade.profiles.*
 import tupperdate.web.legacy.auth.tupperdateAuthPrincipal
 import tupperdate.web.model.Result
 import tupperdate.web.model.map
 import tupperdate.web.model.profiles.User
 
 fun Route.endpoints() {
+    val facade by this.inject<ProfileFacade>()
+    route("/notifications") {
+        post {
+            facade.register(
+                user = requireUser(),
+                token = requireBody<NewNotificationTokenDTO>().toNotificationToken()
+            ).let { respond(it) }
+        }
+    }
     route("/users") {
-        val facade by this.inject<ProfileFacade>()
 
         put("{userId}") {
             facade.save(

--- a/src/web/src/main/java/tupperdate/web/facade/profiles/Koin.kt
+++ b/src/web/src/main/java/tupperdate/web/facade/profiles/Koin.kt
@@ -3,5 +3,5 @@ package tupperdate.web.facade.profiles
 import org.koin.dsl.module
 
 val KoinModuleFacadeProfile = module {
-    factory<ProfileFacade> { ProfileFacadeImpl(get(), get()) }
+    factory<ProfileFacade> { ProfileFacadeImpl(get(), get(), get()) }
 }

--- a/src/web/src/main/java/tupperdate/web/facade/profiles/NewNotificationToken.kt
+++ b/src/web/src/main/java/tupperdate/web/facade/profiles/NewNotificationToken.kt
@@ -1,0 +1,16 @@
+package tupperdate.web.facade.profiles
+
+import tupperdate.common.dto.NewNotificationTokenDTO
+import tupperdate.web.model.profiles.ModelNotificationToken
+
+data class NewNotificationToken(
+    val token: String,
+)
+
+fun NewNotificationTokenDTO.toNotificationToken(): NewNotificationToken {
+    return NewNotificationToken(token)
+}
+
+fun NewNotificationToken.toModelToken(): ModelNotificationToken {
+    return ModelNotificationToken(token)
+}

--- a/src/web/src/main/java/tupperdate/web/facade/profiles/ProfileFacade.kt
+++ b/src/web/src/main/java/tupperdate/web/facade/profiles/ProfileFacade.kt
@@ -15,4 +15,9 @@ interface ProfileFacade {
         user: User,
         profileId: String,
     ): Result<Profile>
+
+    suspend fun register(
+        user: User,
+        token: NewNotificationToken,
+    ): Result<Unit>
 }

--- a/src/web/src/main/java/tupperdate/web/main.kt
+++ b/src/web/src/main/java/tupperdate/web/main.kt
@@ -18,6 +18,7 @@ import tupperdate.web.legacy.routing.accounts.accounts
 import tupperdate.web.legacy.routing.chats.chats
 import tupperdate.web.legacy.routing.recipes.recipes
 import tupperdate.web.legacy.util.getPort
+import tupperdate.web.model.accounts.fcm.KoinModuleModelNotificationFcm
 import tupperdate.web.model.accounts.firestore.KoinModuleModelAuthFirebase
 import tupperdate.web.model.accounts.firestore.KoinModuleModelPhonesFirebase
 import tupperdate.web.model.impl.firestore.KoinModuleModelFirebase
@@ -34,6 +35,7 @@ fun main() {
             modules(KoinModuleModelUsersFirestore)
             modules(KoinModuleModelAuthFirebase)
             modules(KoinModuleModelPhonesFirebase)
+            modules(KoinModuleModelNotificationFcm)
 
             modules(KoinModuleFacadeProfile)
             modules(KoinModuleFacadeAccountReal)

--- a/src/web/src/main/java/tupperdate/web/model/accounts/Notification.kt
+++ b/src/web/src/main/java/tupperdate/web/model/accounts/Notification.kt
@@ -1,0 +1,18 @@
+package tupperdate.web.model.accounts
+
+/**
+ * A sealed class representing the different kinds of notification messages that might be generated
+ * and sent from the server.
+ */
+sealed class Notification {
+
+    // Messages sent to individual users.
+    sealed class ToUser(val user: String): Notification() {
+        class UserSyncAllOwnRecipes(recipient: String) : ToUser(recipient)
+        class UserSyncAllStackRecipes(recipient: String) : ToUser(recipient)
+        class UserSyncAllConversations(recipient: String) : ToUser(recipient)
+        class UserSyncProfile(recipient: String) : ToUser(recipient)
+        class UserSyncOneConversation(recipient: String, val id: String) : ToUser(recipient)
+        class UserSyncOneRecipe(recipient: String, val id: String) : ToUser(recipient)
+    }
+}

--- a/src/web/src/main/java/tupperdate/web/model/accounts/NotificationRepository.kt
+++ b/src/web/src/main/java/tupperdate/web/model/accounts/NotificationRepository.kt
@@ -1,0 +1,14 @@
+package tupperdate.web.model.accounts
+
+import tupperdate.web.model.Result
+
+interface NotificationRepository {
+
+    /**
+     * Sends a specific [Notification]. Some notifications can be sent to individual users, whereas
+     * others are sent to user groups.
+     */
+    suspend fun send(
+        notification: Notification,
+    ): Result<Unit>
+}

--- a/src/web/src/main/java/tupperdate/web/model/accounts/fcm/FcmNotificationRepository.kt
+++ b/src/web/src/main/java/tupperdate/web/model/accounts/fcm/FcmNotificationRepository.kt
@@ -1,0 +1,35 @@
+package tupperdate.web.model.accounts.fcm
+
+import com.google.cloud.firestore.FieldMask
+import com.google.cloud.firestore.Firestore
+import com.google.firebase.messaging.FirebaseMessaging
+import tupperdate.web.legacy.util.await
+import tupperdate.web.model.Result
+import tupperdate.web.model.accounts.Notification
+import tupperdate.web.model.accounts.NotificationRepository
+
+class FcmNotificationRepository(
+    private val messaging: FirebaseMessaging,
+    private val store: Firestore,
+) : NotificationRepository {
+
+    private suspend fun tokenFor(uid: String): String {
+        val document = store.collection("users")
+            .document(uid)
+            .get(FieldMask.of("notifications"))
+            .await()
+        return document["notifications"] as String
+    }
+
+    override suspend fun send(
+        notification: Notification,
+    ): Result<Unit> = try {
+        val message = notification.toMessage(
+            getToken = this::tokenFor,
+        )
+        messaging.sendAsync(message).await()
+        Result.Ok(Unit)
+    } catch (throwable: Throwable) {
+        Result.MissingData()
+    }
+}

--- a/src/web/src/main/java/tupperdate/web/model/accounts/fcm/Koin.kt
+++ b/src/web/src/main/java/tupperdate/web/model/accounts/fcm/Koin.kt
@@ -1,0 +1,8 @@
+package tupperdate.web.model.accounts.fcm
+
+import org.koin.dsl.module
+import tupperdate.web.model.accounts.NotificationRepository
+
+val KoinModuleModelNotificationFcm = module {
+    factory<NotificationRepository> { FcmNotificationRepository(get(), get()) }
+}

--- a/src/web/src/main/java/tupperdate/web/model/accounts/fcm/Notifications.kt
+++ b/src/web/src/main/java/tupperdate/web/model/accounts/fcm/Notifications.kt
@@ -1,0 +1,54 @@
+package tupperdate.web.model.accounts.fcm
+
+import com.google.firebase.messaging.Message
+import tupperdate.common.dto.notifications.Notifications.KeyArgumentConversationId
+import tupperdate.common.dto.notifications.Notifications.KeyArgumentRecipeId
+import tupperdate.common.dto.notifications.Notifications.KeyType
+import tupperdate.common.dto.notifications.Notifications.TypeSyncAllConversations
+import tupperdate.common.dto.notifications.Notifications.TypeSyncAllOwnRecipes
+import tupperdate.common.dto.notifications.Notifications.TypeSyncAllStackRecipes
+import tupperdate.common.dto.notifications.Notifications.TypeSyncOneConversation
+import tupperdate.common.dto.notifications.Notifications.TypeSyncOneRecipe
+import tupperdate.common.dto.notifications.Notifications.TypeSyncProfile
+import tupperdate.web.model.accounts.Notification
+import tupperdate.web.model.accounts.Notification.ToUser
+import tupperdate.web.model.accounts.Notification.ToUser.*
+
+suspend fun Notification.toMessage(
+    getToken: suspend (String) -> String,
+): Message = when (this) {
+    is ToUser -> when (this) {
+
+        is UserSyncAllOwnRecipes -> Message.builder()
+            .setToken(getToken(this.user))
+            .putData(KeyType, TypeSyncAllOwnRecipes)
+            .build()
+
+        is UserSyncAllStackRecipes -> Message.builder()
+            .setToken(getToken(this.user))
+            .putData(KeyType, TypeSyncAllStackRecipes)
+            .build()
+
+        is UserSyncAllConversations -> Message.builder()
+            .setToken(getToken(this.user))
+            .putData(KeyType, TypeSyncAllConversations)
+            .build()
+
+        is UserSyncProfile -> Message.builder()
+            .setToken(getToken(this.user))
+            .putData(KeyType, TypeSyncProfile)
+            .build()
+
+        is UserSyncOneConversation -> Message.builder()
+            .setToken(getToken(this.user))
+            .putData(KeyType, TypeSyncOneConversation)
+            .putData(KeyArgumentConversationId, this.id)
+            .build()
+
+        is UserSyncOneRecipe -> Message.builder()
+            .setToken(getToken(this.user))
+            .putData(KeyType, TypeSyncOneRecipe)
+            .putData(KeyArgumentRecipeId, this.id)
+            .build()
+    }
+}

--- a/src/web/src/main/java/tupperdate/web/model/impl/firestore/Koin.kt
+++ b/src/web/src/main/java/tupperdate/web/model/impl/firestore/Koin.kt
@@ -5,6 +5,7 @@ import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.cloud.FirestoreClient
 import com.google.firebase.cloud.StorageClient
+import com.google.firebase.messaging.FirebaseMessaging
 import org.koin.dsl.module
 import tupperdate.web.legacy.util.initialiseApp
 
@@ -13,4 +14,5 @@ val KoinModuleModelFirebase = module {
     single<Firestore> { FirestoreClient.getFirestore(get()) }
     single<StorageClient> { StorageClient.getInstance(get()) }
     single<FirebaseAuth> { FirebaseAuth.getInstance(get()) }
+    single<FirebaseMessaging> { FirebaseMessaging.getInstance(get()) }
 }

--- a/src/web/src/main/java/tupperdate/web/model/profiles/ModelNotificationToken.kt
+++ b/src/web/src/main/java/tupperdate/web/model/profiles/ModelNotificationToken.kt
@@ -1,0 +1,5 @@
+package tupperdate.web.model.profiles
+
+data class ModelNotificationToken(
+    val value: String,
+)

--- a/src/web/src/main/java/tupperdate/web/model/profiles/UserRepository.kt
+++ b/src/web/src/main/java/tupperdate/web/model/profiles/UserRepository.kt
@@ -10,4 +10,9 @@ interface UserRepository {
     suspend fun read(
         user: User,
     ): Result<ModelUser>
+
+    suspend fun register(
+        user: User,
+        token: ModelNotificationToken,
+    ): Result<Unit>
 }

--- a/src/web/src/test/java/tupperdate/web/koin/Koin.kt
+++ b/src/web/src/test/java/tupperdate/web/koin/Koin.kt
@@ -2,8 +2,12 @@ package tupperdate.web.koin
 
 import org.koin.dsl.module
 import tupperdate.web.facade.accounts.AccountFacade
+import tupperdate.web.model.accounts.NotificationRepository
 import tupperdate.web.model.accounts.PhoneRepository
 
+val KoinModuleNotificationMock = module {
+    factory<NotificationRepository> { NotificationRepositoryMock() }
+}
 
 val KoinModuleFacadeAccountMock = module {
     factory<AccountFacade> { AccountFacadeImplMock() }

--- a/src/web/src/test/java/tupperdate/web/koin/NotificationRepositoryMock.kt
+++ b/src/web/src/test/java/tupperdate/web/koin/NotificationRepositoryMock.kt
@@ -1,0 +1,13 @@
+package tupperdate.web.koin
+
+import tupperdate.web.model.Result
+import tupperdate.web.model.accounts.Notification
+import tupperdate.web.model.accounts.NotificationRepository
+
+class NotificationRepositoryMock : NotificationRepository {
+    override suspend fun send(
+        notification: Notification,
+    ): Result<Unit> {
+        return Result.Ok(Unit)
+    }
+}

--- a/src/web/src/test/java/tupperdate/web/koin/Setup.kt
+++ b/src/web/src/test/java/tupperdate/web/koin/Setup.kt
@@ -5,7 +5,6 @@ import io.ktor.server.testing.*
 import org.koin.ktor.ext.Koin
 import tupperdate.web.facade.profiles.KoinModuleFacadeProfile
 import tupperdate.web.installServer
-import tupperdate.web.model.accounts.firestore.KoinModuleModelPhonesFirebase
 import tupperdate.web.model.impl.firestore.KoinModuleModelFirebase
 import tupperdate.web.model.profiles.firestore.KoinModuleModelUsersFirestore
 
@@ -16,6 +15,7 @@ fun <R> withTupperdateTestApplication(engine: TestApplicationEngine.() -> R): R 
             modules(KoinModuleModelUsersFirestore)
 
             modules(KoinModuleRepositoryPhoneMock)
+            modules(KoinModuleNotificationMock)
 
             modules(KoinModuleFacadeAccountMock)
             modules(KoinModuleFacadeProfile)


### PR DESCRIPTION
This PR adds basic FCM support to send messages from the server to clients. Messages can be sent to unique users, and trigger sync workers on the clients.

Message constants and types are defined in the common `Notifications` object. Notification tokens are automatically uploaded to the backend when changed or issued for the device.